### PR TITLE
fix(auth): add null check before passwordEncoder.matches()

### DIFF
--- a/backend/blog-api/src/main/kotlin/com/contentria/api/auth/application/CredentialService.kt
+++ b/backend/blog-api/src/main/kotlin/com/contentria/api/auth/application/CredentialService.kt
@@ -52,7 +52,8 @@ class CredentialService(
         val credential = (credentialRepository.findByEmail(email)
             ?: throw ContentriaException(ErrorCode.INVALID_CREDENTIALS))
 
-        if (!passwordEncoder.matches(rawPassword, credential.password)) {
+        if (rawPassword == null || credential.password == null
+            || !passwordEncoder.matches(rawPassword, credential.password)) {
             throw ContentriaException(ErrorCode.INVALID_CREDENTIALS)
         }
 


### PR DESCRIPTION
## Summary

- Add null checks for both `rawPassword` and `credential.password` before calling `passwordEncoder.matches()` in `CredentialService.authenticate()`
- Prevents `IllegalArgumentException` when OTP-only users (no password in DB) are targeted by password login attempts
- Prevents BCrypt from comparing the string `"null"` when `rawPassword` is null

## Changed Files

| File | Change |
|------|--------|
| `CredentialService.kt:55` | Add `rawPassword == null \|\| credential.password == null` guard |

## Test plan

- [ ] Password login with valid credentials: works as before
- [ ] Password login with wrong password: returns INVALID_CREDENTIALS
- [ ] Password login with `null` password field: returns INVALID_CREDENTIALS (not 500)
- [ ] Password login for OTP-only user (no password in DB): returns INVALID_CREDENTIALS (not IllegalArgumentException)

closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)