### PR TITLE
fix(api): return all validation errors in details map

### DIFF
--- a/backend/blog-api/src/main/kotlin/com/contentria/api/global/error/GlobalExceptionHandler.kt
+++ b/backend/blog-api/src/main/kotlin/com/contentria/api/global/error/GlobalExceptionHandler.kt
@@ -58,15 +58,15 @@ class GlobalExceptionHandler {
     ): ResponseEntity<ErrorResponse> {
         val requestUri = (request as ServletWebRequest).request.requestURI
         val errorCode = ErrorCode.INVALID_INPUT_VALUE
-        val errorMessage = e.bindingResult.fieldErrors.firstOrNull()?.defaultMessage
-            ?: errorCode.message
+        val fieldErrors = e.bindingResult.fieldErrors.associate { it.field to (it.defaultMessage ?: "invalid") }
 
         val errorResponse = ErrorResponse(
             status = errorCode.status.value(),
             error = errorCode.status.reasonPhrase,
-            message = errorMessage,
+            message = errorCode.message,
             path = requestUri,
-            code = errorCode.code
+            code = errorCode.code,
+            details = fieldErrors
         )
         return ResponseEntity(errorResponse, errorCode.status)
     }


### PR DESCRIPTION
## Summary

- Return all field validation errors in `ErrorResponse.details` instead of only the first one
- `message` field now uses the standard ErrorCode message instead of a single field's error
- Frontend already supports `details: Record<string, string>` in `ApiError` class

## Before / After

**Before:** 3 invalid fields → only 1 error returned
```json
{
  "message": "must not be blank"
}
```

**After:** 3 invalid fields → all errors returned
```json
{
  "message": "Invalid input value.",
  "details": {
    "email": "must not be blank",
    "password": "size must be between 10 and 128",
    "name": "must not be blank"
  }
}
```

## Changed Files

| File | Change |
|------|--------|
| `GlobalExceptionHandler.kt:61` | `firstOrNull()` → `associate { field to message }` into details map |

## Test plan

- [ ] Submit request with multiple invalid fields: all errors appear in `details`
- [ ] Submit request with single invalid field: `details` contains one entry
- [ ] Submit valid request: no change in behavior

closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)