### PR TITLE
feat(media): add rate limiting and upload quotas

### DIFF
--- a/backend/blog-api/src/main/kotlin/com/contentria/api/global/properties/AppProperties.kt
+++ b/backend/blog-api/src/main/kotlin/com/contentria/api/global/properties/AppProperties.kt
@@ -67,6 +67,8 @@ data class R2Properties(
     @field:NotBlank val publicUrl: String,
     val presignedUrlTtlMinutes: Long = 10L,
     val maxFileSizeBytes: Long = 10 * 1024 * 1024, // 10MB
+    val dailyUploadLimitBytes: Long = 100 * 1024 * 1024, // 100MB per user per day
+    val maxImagesPerPost: Int = 20,
 )
 
 @Validated

--- a/backend/blog-api/src/main/kotlin/com/contentria/api/global/util/UserIdResolver.kt
+++ b/backend/blog-api/src/main/kotlin/com/contentria/api/global/util/UserIdResolver.kt
@@ -1,0 +1,22 @@
+package com.contentria.api.global.util
+
+import com.contentria.api.auth.infrastructure.security.AuthUserDetails
+import jakarta.servlet.http.HttpServletRequest
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.stereotype.Component
+
+@Component("userIdResolver")
+class UserIdResolver {
+
+    fun getUserId(request: HttpServletRequest): String {
+        val authentication = SecurityContextHolder.getContext().authentication
+            ?: return request.remoteAddr ?: "unknown"
+
+        val principal = authentication.principal
+        if (principal is AuthUserDetails) {
+            return principal.userId.toString()
+        }
+
+        return request.remoteAddr ?: "unknown"
+    }
+}

--- a/backend/blog-api/src/main/kotlin/com/contentria/api/media/application/MediaService.kt
+++ b/backend/blog-api/src/main/kotlin/com/contentria/api/media/application/MediaService.kt
@@ -11,6 +11,8 @@ import com.contentria.common.global.error.ErrorCode
 import io.github.oshai.kotlinlogging.KotlinLogging
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import java.time.ZonedDateTime
+import java.time.temporal.ChronoUnit
 import java.util.*
 
 private val log = KotlinLogging.logger {}
@@ -28,6 +30,7 @@ class MediaService(
     fun createPresignedUrl(userId: UUID, command: PresignedUrlCommand): PresignedUrlInfo {
         validateFileType(command.contentType)
         validateFileSize(command.fileSize)
+        validateDailyUploadQuota(userId, command.fileSize)
 
         val extension = extractExtension(command.fileName)
         // Upload to the temporary prefix. Objects are promoted to the permanent prefix
@@ -126,6 +129,8 @@ class MediaService(
     @Transactional
     fun syncMediaForPost(postId: UUID, markdown: String) {
         val currentImageUrls = extractImageUrls(markdown)
+        validatePostImageLimit(currentImageUrls.size)
+
         val previousMedia = mediaRepository.findByPostId(postId)
         val previousUrls = previousMedia.map { it.publicUrl }
 
@@ -163,6 +168,21 @@ class MediaService(
     private fun validateFileSize(fileSize: Long) {
         if (fileSize > appProperties.r2.maxFileSizeBytes) {
             throw ContentriaException(ErrorCode.MEDIA_FILE_TOO_LARGE)
+        }
+    }
+
+    private fun validateDailyUploadQuota(userId: UUID, fileSize: Long) {
+        val startOfDay = ZonedDateTime.now().truncatedTo(ChronoUnit.DAYS)
+        val usedBytes = mediaRepository.sumFileSizeByUploaderIdAndCreatedAtAfter(userId, startOfDay)
+        if (usedBytes + fileSize > appProperties.r2.dailyUploadLimitBytes) {
+            log.warn { "Daily upload quota exceeded: userId=$userId, usedBytes=$usedBytes, requestedBytes=$fileSize" }
+            throw ContentriaException(ErrorCode.MEDIA_DAILY_UPLOAD_QUOTA_EXCEEDED)
+        }
+    }
+
+    private fun validatePostImageLimit(imageCount: Int) {
+        if (imageCount > appProperties.r2.maxImagesPerPost) {
+            throw ContentriaException(ErrorCode.MEDIA_POST_IMAGE_LIMIT_EXCEEDED)
         }
     }
 

--- a/backend/blog-api/src/main/kotlin/com/contentria/api/media/domain/MediaRepository.kt
+++ b/backend/blog-api/src/main/kotlin/com/contentria/api/media/domain/MediaRepository.kt
@@ -1,5 +1,6 @@
 package com.contentria.api.media.domain
 
+import java.time.ZonedDateTime
 import java.util.*
 
 interface MediaRepository {
@@ -10,4 +11,6 @@ interface MediaRepository {
     fun deleteAll(media: List<Media>)
     fun findByPublicUrlIn(publicUrls: List<String>): List<Media>
     fun findByPostId(postId: UUID): List<Media>
+    fun sumFileSizeByUploaderIdAndCreatedAtAfter(uploaderId: UUID, since: ZonedDateTime): Long
+    fun countByPostId(postId: UUID): Int
 }

--- a/backend/blog-api/src/main/kotlin/com/contentria/api/media/infrastructure/MediaJpaRepository.kt
+++ b/backend/blog-api/src/main/kotlin/com/contentria/api/media/infrastructure/MediaJpaRepository.kt
@@ -2,7 +2,9 @@ package com.contentria.api.media.infrastructure
 
 import com.contentria.api.media.domain.Media
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
+import java.time.ZonedDateTime
 import java.util.*
 
 @Repository
@@ -10,4 +12,9 @@ interface MediaJpaRepository : JpaRepository<Media, UUID> {
 
     fun findByPublicUrlIn(publicUrls: List<String>): List<Media>
     fun findByPostId(postId: UUID): List<Media>
+
+    @Query("SELECT COALESCE(SUM(m.fileSize), 0) FROM Media m WHERE m.uploaderId = :uploaderId AND m.createdAt > :since")
+    fun sumFileSizeByUploaderIdAndCreatedAtAfter(uploaderId: UUID, since: ZonedDateTime): Long
+
+    fun countByPostId(postId: UUID): Int
 }

--- a/backend/blog-api/src/main/kotlin/com/contentria/api/media/infrastructure/MediaRepositoryImpl.kt
+++ b/backend/blog-api/src/main/kotlin/com/contentria/api/media/infrastructure/MediaRepositoryImpl.kt
@@ -4,6 +4,7 @@ import com.contentria.api.media.domain.Media
 import com.contentria.api.media.domain.MediaRepository
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Repository
+import java.time.ZonedDateTime
 import java.util.*
 
 @Repository
@@ -33,5 +34,13 @@ class MediaRepositoryImpl(
 
     override fun findByPostId(postId: UUID): List<Media> {
         return mediaJpaRepository.findByPostId(postId)
+    }
+
+    override fun sumFileSizeByUploaderIdAndCreatedAtAfter(uploaderId: UUID, since: ZonedDateTime): Long {
+        return mediaJpaRepository.sumFileSizeByUploaderIdAndCreatedAtAfter(uploaderId, since)
+    }
+
+    override fun countByPostId(postId: UUID): Int {
+        return mediaJpaRepository.countByPostId(postId)
     }
 }

--- a/backend/blog-api/src/main/resources/application.yaml
+++ b/backend/blog-api/src/main/resources/application.yaml
@@ -54,6 +54,7 @@ spring:
       provider: com.github.benmanes.caffeine.jcache.spi.CaffeineCachingProvider # Cache Provider가 하나일 경우 생략 가능하지만, 명시성을 위해 기입
     cache-names:
       - rateLimiting
+      - mediaRateLimiting
       - verificationCode
     caffeine:
       spec: maximumSize=1000,expireAfterAccess=300s
@@ -93,6 +94,24 @@ bucket4j:
               initial-capacity: 10
               time: 1
               unit: minutes
+              refill-speed: interval
+    - id: mediaRateLimitingFilter
+      cache-name: mediaRateLimiting
+      url: "/api/media/presigned-url"
+      http-content-type: "application/json;charset=UTF-8"
+      http-status-code: TOO_MANY_REQUESTS
+      http-response-body: '{"status":429,"code":"C0008","error":"Too Many Requests","message":"Too many requests. Please try again later."}'
+      filter-order: 90
+      rate-limits:
+        - cache-key: "@userIdResolver.getUserId(#root)"
+          bandwidths:
+            - capacity: 30
+              time: 1
+              unit: minutes
+              refill-speed: interval
+            - capacity: 100
+              time: 1
+              unit: days
               refill-speed: interval
 
 app:

--- a/backend/blog-common/src/main/kotlin/com/contentria/common/global/error/ErrorCode.kt
+++ b/backend/blog-common/src/main/kotlin/com/contentria/common/global/error/ErrorCode.kt
@@ -57,6 +57,8 @@ enum class ErrorCode(
     UNSUPPORTED_MEDIA_TYPE(HttpStatus.BAD_REQUEST, "ME0001", "Unsupported file type. Allowed: JPEG, PNG, WebP, GIF."),
     MEDIA_FILE_TOO_LARGE(HttpStatus.BAD_REQUEST, "ME0002", "File size exceeds the maximum allowed limit."),
     MEDIA_DELETE_FORBIDDEN(HttpStatus.FORBIDDEN, "ME0003", "You do not have permission to delete this media."),
+    MEDIA_DAILY_UPLOAD_QUOTA_EXCEEDED(HttpStatus.TOO_MANY_REQUESTS, "ME0004", "Daily upload quota exceeded. Please try again tomorrow."),
+    MEDIA_POST_IMAGE_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST, "ME0005", "Maximum number of images per post exceeded."),
 
     // Markdown
     MARKDOWN_PROCESSING_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "MD0000", "An error occurred while processing the markdown content."),


### PR DESCRIPTION
## Summary

- Per-user rate limit on `POST /api/media/presigned-url` using Bucket4j (30/min + 100/day)
- Daily per-user upload byte quota (100MB/day, DB-enforced via cumulative `fileSize` query)
- Per-post image count limit (20 images/post, enforced in `syncMediaForPost`)

## Implementation details

### 1. Bucket4j rate limiting (request count)

Added a second Bucket4j filter (`mediaRateLimitingFilter`) in `application.yaml`:
- **Cache**: `mediaRateLimiting` (Caffeine JCache, separate from the auth rate limit cache)
- **Key**: `@userIdResolver.getUserId(#root)` — extracts userId from `SecurityContextHolder`
- **Bands**: 30 req/min + 100 req/day
- **filter-order: 90** — ensures it runs after Spring Security populates the authentication context
- Returns `429 Too Many Requests` with standard error JSON on limit breach

### 2. Daily upload byte quota (100MB/day)

In `MediaService.createPresignedUrl`, before creating the media record:
- Queries `SUM(file_size)` for the user's uploads since start of day
- Rejects with `ME0004 MEDIA_DAILY_UPLOAD_QUOTA_EXCEEDED` if adding the new file would exceed the daily limit
- Configurable via `app.r2.daily-upload-limit-bytes` (default 100MB)

### 3. Per-post image count limit (20 images/post)

In `MediaService.syncMediaForPost`, before linking:
- Counts image URLs extracted from the markdown
- Rejects with `ME0005 MEDIA_POST_IMAGE_LIMIT_EXCEEDED` if count exceeds the limit
- Configurable via `app.r2.max-images-per-post` (default 20)

## New files

- `UserIdResolver.kt` — Spring bean that extracts userId from `SecurityContextHolder` for Bucket4j cache key

## Changed files

| File | Change |
|---|---|
| `application.yaml` | Added `mediaRateLimitingFilter`, `mediaRateLimiting` cache |
| `AppProperties.kt` | Added `dailyUploadLimitBytes`, `maxImagesPerPost` to `R2Properties` |
| `MediaService.kt` | Added `validateDailyUploadQuota`, `validatePostImageLimit` |
| `MediaRepository.kt` | Added `sumFileSizeByUploaderIdAndCreatedAtAfter`, `countByPostId` |
| `MediaJpaRepository.kt` | Added JPQL sum query, Spring Data derived count query |
| `MediaRepositoryImpl.kt` | Delegate implementations |
| `ErrorCode.kt` | Added `ME0004`, `ME0005` |

## Test plan

- [ ] Upload images rapidly (>30 in a minute) → expect `429` after limit
- [ ] Upload images throughout the day exceeding 100MB total → expect `ME0004`
- [ ] Create a post with >20 images in markdown → expect `ME0005`
- [ ] Normal upload flow (1-5 images per post) works without hitting limits
- [ ] Verify rate limit response body matches standard error format

closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)