### PR TITLE
feat(frontend): add nosniff and Referrer-Policy security headers

### DIFF
--- a/backend/docs/media-upload-hardening.md
+++ b/backend/docs/media-upload-hardening.md
@@ -154,20 +154,30 @@ User-uploaded images are served from `images.contentria.com` (Cloudflare R2 cust
 | `Content-Security-Policy` on image pages | Restricts what scripts/styles can execute on pages rendering user images | Must be carefully scoped to avoid breaking legitimate functionality |
 | `Content-Disposition: attachment` | Forces download instead of inline rendering | Breaks `<img>` tags; only appropriate for non-image file types |
 
-**Decision:** Apply `X-Content-Type-Options: nosniff` via Cloudflare Transform Rules on all `images.contentria.com` responses. This is the browser-side complement to server-side magic number validation (#10) — even if a polyglot file slips through, the browser will not re-interpret `image/jpeg` as `text/html`.
+**Decision:** Apply `X-Content-Type-Options: nosniff` in two places:
 
-CSP tightening on the Next.js side can be done incrementally and is a broader concern than just media uploads.
+1. **Cloudflare Transform Rules** on `images.contentria.com` — covers all R2-served image responses.
+2. **Next.js `headers()` config** — covers all responses served from the Next.js app itself (pages, API routes, static assets).
+
+This is the browser-side complement to server-side magic number validation (#10). Even if a polyglot file bypasses server validation, the browser will not re-interpret `image/jpeg` as `text/html`.
+
+**Trust model note:** `nosniff` does not defend against network-layer MITM header tampering — that concern is already handled by HTTPS/TLS integrity guarantees. `nosniff` defends against the browser's own "helpful" MIME sniffing behavior when a server-declared `Content-Type` looks suspicious to the browser.
+
+`Referrer-Policy: strict-origin-when-cross-origin` was also added to prevent leaking post slugs and query parameters to third-party resources via the `Referer` header.
+
+CSP tightening on the Next.js side (beyond `frame-ancestors`) is deferred — it is a broader concern than media uploads and requires per-page evaluation to avoid breaking legitimate functionality.
 
 `Content-Disposition: attachment` is not applicable today since only image formats are served inline via `<img>` tags.
 
 ### Action
 
-- Configure Cloudflare Transform Rule: `X-Content-Type-Options: nosniff` on `images.contentria.com`.
-- No backend code changes required — this is purely a CDN configuration.
+- **Cloudflare Dashboard** (manual): Configure a Transform Rule adding `X-Content-Type-Options: nosniff` to all responses from `images.contentria.com`.
+- **`frontend/next.config.ts`**: Add `X-Content-Type-Options: nosniff` and `Referrer-Policy: strict-origin-when-cross-origin` to the global `headers()` configuration.
 
 ### Result
 
-- Browser MIME sniffing is disabled for all CDN-served assets.
+- Browser MIME sniffing is disabled for both CDN-served assets and Next.js app responses.
+- Cross-origin `Referer` leakage is limited to origin-only on cross-origin navigations.
 - Combined with magic number validation (#10), the attack surface for file-type spoofing is closed at both server and browser layers.
 
 ---

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -40,6 +40,20 @@ const nextConfig: NextConfig = {
             key: 'Content-Security-Policy',
             value: "frame-ancestors 'self' https://accounts.google.com",
           },
+          // Prevent MIME-sniffing. If a response is served with an incorrect Content-Type,
+          // the browser must not re-interpret it based on content (e.g. rendering a
+          // disguised HTML file as a script). Complements server-side magic number
+          // validation for uploaded images (see backend/docs/media-upload-hardening.md).
+          {
+            key: 'X-Content-Type-Options',
+            value: 'nosniff',
+          },
+          // Strip path/query from cross-origin Referer to avoid leaking post slugs or
+          // query parameters to third-party resources (images, analytics, etc.).
+          {
+            key: 'Referrer-Policy',
+            value: 'strict-origin-when-cross-origin',
+          },
         ],
       },
     ];


### PR DESCRIPTION
## Summary
- Add `X-Content-Type-Options: nosniff` to all Next.js responses, preventing browsers from MIME-sniffing pages and static assets. Complements server-side magic number validation (#10).
- Add `Referrer-Policy: strict-origin-when-cross-origin` to avoid leaking post slugs and query parameters to third-party resources via the Referer header.
- Update `backend/docs/media-upload-hardening.md` #12 section: clarify the trust model (HTTPS handles MITM; nosniff handles browser MIME sniffing) and record the dual-layer design (Cloudflare Transform Rule + Next.js headers).

## Out of scope for code
- The Cloudflare Transform Rule that applies `nosniff` on `images.contentria.com` is configured manually via the Cloudflare dashboard — no code change needed for the CDN side.
- Broader CSP tightening (beyond `frame-ancestors`) is deferred; it requires per-page evaluation and is a concern larger than media uploads.

## Test plan
- [ ] Run `npm run build` to confirm no config errors.
- [ ] Start `next start` locally and `curl -I http://localhost:3000/` to verify `X-Content-Type-Options: nosniff` and `Referrer-Policy: strict-origin-when-cross-origin` are present in response headers.
- [ ] Verify existing headers (`Cross-Origin-Opener-Policy`, `Cross-Origin-Embedder-Policy`, `Content-Security-Policy`) are unchanged.
- [ ] (Manual) Confirm Cloudflare Transform Rule on `images.contentria.com` returns `X-Content-Type-Options: nosniff` for a sample image URL.

closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)