### PR TITLE
fix(auth): return 204 from signup initiate endpoint

### DIFF
--- a/backend/blog-api/src/main/kotlin/com/contentria/api/auth/controller/AuthController.kt
+++ b/backend/blog-api/src/main/kotlin/com/contentria/api/auth/controller/AuthController.kt
@@ -71,7 +71,7 @@ class AuthController(
 
         val command = request.toCommand(clientIp)
         authFacade.initiate(command)
-        return ResponseEntity.ok().build()
+        return ResponseEntity.noContent().build()
     }
 
     @PostMapping("/verify-code")


### PR DESCRIPTION
## Summary

- Changed `AuthController.initiateSignUp` to return `ResponseEntity.noContent().build()` (HTTP 204) instead of `ResponseEntity.ok().build()` (HTTP 200 with empty body).

## Why

The frontend `apiServer.fetchExtended` handles empty-body responses only when the status is 204. The sign-up initiate endpoint was returning 200 with no body, so the success path tried to parse the empty body as JSON and threw `Unexpected end of JSON input`. This surfaced visibly when the user solved the reCAPTCHA v2 challenge on the sign-up flow, but it also affected the v3-pass path.

Using 204 is also more correct semantically: the operation produces no response resource.

Closes #33

## Test plan

- [ ] Sign up with a new email (v3 passes) → backend returns 204 → frontend transitions to OTP step without JSON errors.
- [ ] Sign up with a new email (v3 fails) → solve v2 → backend returns 204 → frontend transitions to OTP step.
- [ ] Verify the OTP code still completes sign-up successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)