### PR TITLE
fix(auth): reuse pending verification code instead of throwing 429

### DIFF
--- a/backend/blog-api/src/main/kotlin/com/contentria/api/auth/infrastructure/MailVerificationProvider.kt
+++ b/backend/blog-api/src/main/kotlin/com/contentria/api/auth/infrastructure/MailVerificationProvider.kt
@@ -25,8 +25,9 @@ class MailVerificationProvider(
         val cache = getCacheOrThrow()
 
         if (cache.get(email) != null) {
-            log.warn { "Verification code requested too frequently" }
-            throw ContentriaException(ErrorCode.TOO_MANY_REQUESTS)
+            // Reuse the pending code so the email already in the inbox stays valid.
+            log.info { "Verification code already pending; skipping send." }
+            return
         }
 
         val code = generateRandomCode()


### PR DESCRIPTION
## Summary

- `MailVerificationProvider.sendVerificationCode` now short-circuits with a logged no-op when the `verificationCode` cache still holds an entry for the email, instead of throwing `TOO_MANY_REQUESTS`.

## Why

A user who accidentally navigated away from the OTP input screen was blocked for the full five-minute cache TTL. Their valid code was still sitting in their inbox, but every retry of sign-up or OTP login rolled back on the backend with a 429, leaving the user with no path forward.

Because the cache already holds a valid, unexpired code, the right behavior is to keep reusing it rather than generate a new one. The outbound email is skipped, so anti-spam guarantees are preserved, and the frontend transitions to the OTP screen as usual — letting the user enter the code they already received.

Handling the separate case of a user who never received the original email (spam filter, delivery failure) would require a short-cooldown resend mechanism and is intentionally out of scope.

Closes #37

## Test plan

- [ ] Start sign-up, receive verification code in inbox, leave the OTP screen, return within 5 minutes, and trigger sign-up or OTP login again → the flow reaches the OTP input screen and the original code still verifies successfully.
- [ ] Without any prior pending code, verify that sign-up and OTP login still send a fresh email as before.
- [ ] Password login for an unverified account still returns `USER_NOT_ACTIVATED` (unchanged by this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)