### PR TITLE
fix(dashboard): refresh after blog creation resolves, not before

### DIFF
--- a/frontend/src/components/dashboard/CreateBlogWelcome.tsx
+++ b/frontend/src/components/dashboard/CreateBlogWelcome.tsx
@@ -31,12 +31,11 @@ export default function CreateBlogWelcome() {
   const { mutate: createBlog, isPending, error } = useCreateBlogMutation();
 
   const onSubmit: SubmitHandler<FormValues> = (data) => {
-    try {
-      createBlog(data);
-      router.refresh(); // 블로그 생성 후 대시보드 새로고침
-    } catch (error) {
-      console.error('블로그 생성 실패:', error);
-    }
+    createBlog(data, {
+      onSuccess: () => {
+        router.refresh();
+      },
+    });
   };
 
   return (


### PR DESCRIPTION
## Summary

- Moved `router.refresh()` into the `createBlog` mutation's per-call `onSuccess` callback so the dashboard re-renders only after the blog actually exists on the server.
- Removed the unreachable `try/catch` around `mutate`, which never throws.

## Why

The previous implementation fired the mutation and called `router.refresh()` on the same tick. Because `mutate` is fire-and-forget, the server component re-fetched before the backend had created the blog and kept rendering the welcome form. The first click appeared to stall; a second click returned `DUPLICATE_BLOG_SLUG` and the error banner flashed for a moment before the second refresh finally picked up the new blog and replaced the view with the normal dashboard.

Closes #39

## Test plan

- [ ] Sign up, log in, and reach the blog-create welcome screen.
- [ ] Enter a valid slug, click the create button once, and verify the dashboard transitions to the blog view without a second click.
- [ ] Enter an invalid (already-taken) slug and confirm the duplicate-slug error renders cleanly and stays on screen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)