### PR TITLE
fix(ui): show nickname instead of username on dashboard and post author

### DIFF
--- a/backend/blog-api/src/main/kotlin/com/contentria/api/post/controller/dto/PostDetailResponse.kt
+++ b/backend/blog-api/src/main/kotlin/com/contentria/api/post/controller/dto/PostDetailResponse.kt
@@ -42,14 +42,14 @@ data class PostDetailResponse(
 
     data class AuthorResponse(
         val userId: UUID,
-        val username: String,
+        val nickname: String,
         val profileImageUrl: String?
     ) {
         companion object {
             fun from(info: UserInfo): AuthorResponse {
                 return AuthorResponse(
                     userId = info.userId,
-                    username = info.username,
+                    nickname = info.nickname,
                     profileImageUrl = info.pictureUrl
                 )
             }

--- a/frontend/src/app/user/[blogSlug]/posts/[postSlug]/page.tsx
+++ b/frontend/src/app/user/[blogSlug]/posts/[postSlug]/page.tsx
@@ -91,7 +91,7 @@ export default async function PostDetailPage({ params }: PostDetailPageProps) {
               {post.title}
             </h1>
             <div className="flex items-center space-x-3 text-sm text-gray-500">
-              <span className="font-semibold text-indigo-600">{author.username}</span>
+              <span className="font-semibold text-indigo-600">{author.nickname}</span>
               <span>•</span>
               <time dateTime={post.publishedAt}>
                 {new Date(post.publishedAt).toLocaleDateString('ko-KR')}

--- a/frontend/src/components/dashboard/DashboardContent.tsx
+++ b/frontend/src/components/dashboard/DashboardContent.tsx
@@ -42,7 +42,7 @@ export default function DashboardContent({ user, blogInfos }: DashboardContentPr
         <div>
           <h1 className="text-2xl font-bold text-gray-800">대시보드</h1>
           <p className="mt-1 text-sm text-gray-500">
-            안녕하세요, {user?.username || '관리자'}님! 오늘의 블로그 현황입니다.
+            안녕하세요, {user?.nickname || '관리자'}님! 오늘의 블로그 현황입니다.
           </p>
         </div>
         <Link

--- a/frontend/src/types/api/user.ts
+++ b/frontend/src/types/api/user.ts
@@ -14,7 +14,7 @@ export interface UserSummaryResponse {
 
 export interface AuthorResponse {
   userId: string;
-  username: string;
+  nickname: string;
   profileImageUrl: string | null;
 }
 


### PR DESCRIPTION
## Summary

- Dashboard greeting in `DashboardContent.tsx` now reads `user.nickname` instead of `user.username`.
- Public post author line in `app/user/[blogSlug]/posts/[postSlug]/page.tsx` now renders `author.nickname`.
- `AuthorResponse` DTO on the backend (`PostDetailResponse.kt`) and the matching frontend type expose `nickname` in place of `username`.

## Why

The app consistently surfaces the randomly generated nickname (e.g. `따듯한_코알라_6312`) in the profile dropdown, so users expect to see the same handle in the dashboard greeting and on their published posts. The earlier code was leaking the `username` field, which the product treats as a private real-name value that only the settings screen should expose.

Closes #41

## Test plan

- [ ] Log in → dashboard greeting displays the same nickname shown in the profile dropdown.
- [ ] Open a post on a published blog → the author line displays the nickname.
- [ ] Edit nickname in settings → both surfaces reflect the new value after refresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)