### PR TITLE
fix(analytics): deduplicate page views within a 30-minute cooldown

### DIFF
--- a/backend/blog-api/src/main/kotlin/com/contentria/api/analytics/application/AnalyticsInternalService.kt
+++ b/backend/blog-api/src/main/kotlin/com/contentria/api/analytics/application/AnalyticsInternalService.kt
@@ -7,6 +7,8 @@ import io.github.oshai.kotlinlogging.KotlinLogging
 import org.springframework.scheduling.annotation.Async
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import java.time.Duration
+import java.time.ZonedDateTime
 
 private val log = KotlinLogging.logger {  }
 
@@ -18,6 +20,10 @@ class AnalyticsInternalService(
     @Transactional
     fun logVisit(command: LogVisitCommand) {
         try {
+            if (shouldSkipAsDuplicate(command)) {
+                log.debug { "Skipping visit log within cooldown window." }
+                return
+            }
             val visitLog = VisitLog.create(
                 blogId = command.blogId,
                 postId = command.postId,
@@ -30,5 +36,20 @@ class AnalyticsInternalService(
         } catch (e: Exception) {
             log.error(e) { "Failed to save visit log async" }
         }
+    }
+
+    private fun shouldSkipAsDuplicate(command: LogVisitCommand): Boolean {
+        val ip = command.visitorIp ?: return false
+        val since = ZonedDateTime.now().minus(PV_COOLDOWN)
+        return visitLogRepository.existsRecentVisit(
+            blogId = command.blogId,
+            postId = command.postId,
+            visitorIp = ip,
+            since = since
+        )
+    }
+
+    companion object {
+        private val PV_COOLDOWN: Duration = Duration.ofMinutes(30)
     }
 }

--- a/backend/blog-api/src/main/resources/db/schema.sql
+++ b/backend/blog-api/src/main/resources/db/schema.sql
@@ -190,6 +190,7 @@ CREATE TABLE visit_logs (
 );
 
 CREATE INDEX idx_visit_logs_date ON visit_logs (blog_id, visited_at);
+CREATE INDEX idx_visit_logs_dedup ON visit_logs (blog_id, post_id, visitor_ip, visited_at);
 
 CREATE TABLE daily_statistics (
     id UUID PRIMARY KEY,

--- a/backend/blog-common/src/main/kotlin/com/contentria/common/domain/analytics/VisitLog.kt
+++ b/backend/blog-common/src/main/kotlin/com/contentria/common/domain/analytics/VisitLog.kt
@@ -8,10 +8,14 @@ import java.util.*
 @Entity
 @Table(
     name = "visit_logs",
-    schema = "contentria"
-//    indexes = [
-//        Index(name = "idx_visit_logs_blot_date", columnList = "blog_id, visited_at")
-//    ]
+    schema = "contentria",
+    indexes = [
+        Index(name = "idx_visit_logs_date", columnList = "blog_id, visited_at"),
+        Index(
+            name = "idx_visit_logs_dedup",
+            columnList = "blog_id, post_id, visitor_ip, visited_at"
+        )
+    ]
 )
 class VisitLog(
     @Id

--- a/backend/blog-common/src/main/kotlin/com/contentria/common/domain/analytics/repository/VisitLogJpaRepository.kt
+++ b/backend/blog-common/src/main/kotlin/com/contentria/common/domain/analytics/repository/VisitLogJpaRepository.kt
@@ -23,4 +23,19 @@ interface VisitLogJpaRepository : JpaRepository<VisitLog, UUID> {
         AND v.visitedAt >= :startOfDay
     """)
     fun countTodayViews(blogId: UUID, startOfDay: ZonedDateTime): Long
+
+    @Query("""
+        SELECT CASE WHEN COUNT(v) > 0 THEN TRUE ELSE FALSE END
+        FROM VisitLog v
+        WHERE v.blogId = :blogId
+        AND ((:postId IS NULL AND v.postId IS NULL) OR v.postId = :postId)
+        AND v.visitorIp = :visitorIp
+        AND v.visitedAt >= :since
+    """)
+    fun existsRecentVisit(
+        blogId: UUID,
+        postId: UUID?,
+        visitorIp: String,
+        since: ZonedDateTime
+    ): Boolean
 }

--- a/backend/blog-common/src/main/kotlin/com/contentria/common/domain/analytics/repository/VisitLogRepository.kt
+++ b/backend/blog-common/src/main/kotlin/com/contentria/common/domain/analytics/repository/VisitLogRepository.kt
@@ -15,4 +15,11 @@ interface VisitLogRepository {
     fun countTodayVisitors(blogId: UUID, startOfToday: ZonedDateTime): Long
 
     fun countTodayViews(blogId: UUID, startOfDay: ZonedDateTime): Long
+
+    fun existsRecentVisit(
+        blogId: UUID,
+        postId: UUID?,
+        visitorIp: String,
+        since: ZonedDateTime
+    ): Boolean
 }

--- a/backend/blog-common/src/main/kotlin/com/contentria/common/domain/analytics/repository/VisitLogRepositoryImpl.kt
+++ b/backend/blog-common/src/main/kotlin/com/contentria/common/domain/analytics/repository/VisitLogRepositoryImpl.kt
@@ -37,4 +37,13 @@ class VisitLogRepositoryImpl(
     override fun countTodayViews(blogId: UUID, startOfDay: ZonedDateTime): Long {
         return jpaRepository.countTodayViews(blogId, startOfDay)
     }
+
+    override fun existsRecentVisit(
+        blogId: UUID,
+        postId: UUID?,
+        visitorIp: String,
+        since: ZonedDateTime
+    ): Boolean {
+        return jpaRepository.existsRecentVisit(blogId, postId, visitorIp, since)
+    }
 }


### PR DESCRIPTION
## Summary

- Skip persisting a `VisitLog` when the same `(blogId, postId, visitorIp)` already logged a visit within the last 30 minutes. A refresh no longer increments PV; a genuine return visit after the window still does.
- Restore the `(blog_id, visited_at)` index on `visit_logs` (previously commented out on the entity) and add a composite `(blog_id, post_id, visitor_ip, visited_at)` index so the dedup existence check stays cheap.
- UV semantics (`COUNT(DISTINCT visitor_ip)`) are unchanged.

## Rationale

Blog platforms conventionally deduplicate PV per visitor within a cooldown window (commonly 30 min) rather than counting every page load, because "how many people read this post" is more useful than "how many times the page was loaded." Current behavior counts every refresh, letting counts inflate trivially.

## Test plan

- [ ] Load a post detail page → PV +1.
- [ ] Refresh the same page repeatedly within 30 minutes → PV unchanged; logs show cooldown skip.
- [ ] Wait >30 minutes and reload → PV +1 again.
- [ ] Different IP visits same post → PV +1 and UV +1.
- [ ] Two different posts from the same IP → each +1 PV independently.
- [ ] `./gradlew :blog-api:build :blog-common:build` passes.

closes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)